### PR TITLE
Fix history and prompt paths

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -35,6 +35,9 @@ MAX_CHAT_HISTORY = int(os.getenv("MAX_CHAT_HISTORY", 10))
 ENV = os.getenv("ENV", "prod")
 INACTIVITY_THRESHOLD = timedelta(minutes=10)
 # TODO: better manage the mount volume path
+# NOTE: the production GCP bucket contains nested "history" and "prompts"
+# directories.  Until that layout is updated, the base paths intentionally
+# repeat the folder names.
 HISTORY_BASE_PATH = "/history/history/" if ENV == "prod" else "history"
 PROMPT_BASE_PATH = "/prompts/prompts/" if ENV == "prod" else "prompts"
 


### PR DESCRIPTION
## Summary
- restore double directory paths in `HISTORY_BASE_PATH` and `PROMPT_BASE_PATH`
- document why the nested paths exist

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683ffba98060832eaf3f5d52c83e8e74