### PR TITLE
Add default prompt fallbacks

### DIFF
--- a/app/prompt.py
+++ b/app/prompt.py
@@ -10,7 +10,17 @@ import os
 from app.config import PROMPT_BASE_PATH
 
 
-def _load_prompt(file_name: str) -> str:
+DEFAULT_AUTHOR = "Anonymous"
+DEFAULT_GENERAL_PROMPT = (
+    "Respond concisely and helpfully to the user."
+)
+DEFAULT_TEXT_SYSTEM_PROMPT = "You are a helpful assistant."
+DEFAULT_VISION_SYSTEM_PROMPT = (
+    "You are a helpful assistant capable of understanding images."
+)
+
+
+def _load_prompt(file_name: str, default: str) -> str:
     """
     Load a prompt template from a file.
 
@@ -24,24 +34,29 @@ def _load_prompt(file_name: str) -> str:
         RuntimeError: If the file is not found or cannot be read.
     """
     file_path = os.path.join(PROMPT_BASE_PATH, file_name)
-    # print(f"Loading prompt from {file_path}")
     try:
         with open(file_path, "r", encoding="utf-8") as f:
-            return f.read()
+            content = f.read()
+            if content.strip():
+                return content
+            print(f"Warning: prompt file {file_path} is empty, using default")
     except FileNotFoundError:
-        raise RuntimeError(f"Prompt file not found: {file_path}")
+        print(f"Warning: prompt file not found: {file_path}. Using default.")
     except Exception as e:
-        raise RuntimeError(f"Error loading prompt file '{file_path}': {e}")
+        print(
+            f"Warning: error reading prompt file '{file_path}': {e}. Using default."
+        )
+    return default
 
 
-_AUTHOR = _load_prompt("author.txt")
-_GENERAL_PROMPT = _load_prompt("general_prompt.txt")
+_AUTHOR = _load_prompt("author.txt", DEFAULT_AUTHOR)
+_GENERAL_PROMPT = _load_prompt("general_prompt.txt", DEFAULT_GENERAL_PROMPT)
 
 TEXT_SYSTEM_PROMPT = (
-    f"{_load_prompt('text_system_prompt.txt')}\n"
+    f"{_load_prompt('text_system_prompt.txt', DEFAULT_TEXT_SYSTEM_PROMPT)}\n"
     f"{_GENERAL_PROMPT}\n"
     f"About the author: {_AUTHOR}"
 )
 VISION_SYSTEM_PROMPT = (
-    f"{_load_prompt('vision_system_prompt.txt')}\n" f"{_GENERAL_PROMPT}"
+    f"{_load_prompt('vision_system_prompt.txt', DEFAULT_VISION_SYSTEM_PROMPT)}\n" f"{_GENERAL_PROMPT}"
 )


### PR DESCRIPTION
## Summary
- provide default system prompts in `app/prompt.py`
- log warnings when prompt files are missing or empty

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68403cf8b290832eb2e7b4956ba80ac5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved prompt loading to handle missing or unreadable files gracefully, displaying warnings and using fallback content instead of causing errors.

- **Chores**
  - Enhanced system reliability by introducing default prompts for various features, ensuring continued operation even if prompt files are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->